### PR TITLE
Session destroy

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -325,7 +325,7 @@ func (cfg Configuration) handleSessionUpdate(w http.ResponseWriter, r *http.Requ
 
 func (cfg Configuration) handleSessionDestroy(w http.ResponseWriter, r *http.Request) {
 	setDefaultHeaders(w)
-	log.Printf("Destroyin session")
+
 	secret := r.FormValue("secret")
 	cfg.db.destroySession(secret)
 }

--- a/backend/api.go
+++ b/backend/api.go
@@ -325,10 +325,9 @@ func (cfg Configuration) handleSessionUpdate(w http.ResponseWriter, r *http.Requ
 
 func (cfg Configuration) handleSessionDestroy(w http.ResponseWriter, r *http.Request) {
 	setDefaultHeaders(w)
-
+	log.Printf("Destroyin session")
 	secret := r.FormValue("secret")
-
-	log.Printf("Session destroyed: %v", secret);
+	cfg.db.destroySession(secret)
 }
 
 func (cfg Configuration) handleMetrics(w http.ResponseWriter, r *http.Request) {

--- a/backend/api.go
+++ b/backend/api.go
@@ -323,6 +323,14 @@ func (cfg Configuration) handleSessionUpdate(w http.ResponseWriter, r *http.Requ
 	cfg.db.setStatus(secret, status)
 }
 
+func (cfg Configuration) handleSessionDestroy(w http.ResponseWriter, r *http.Request) {
+	setDefaultHeaders(w)
+
+	secret := r.FormValue("secret")
+
+	log.Printf("Session destroyed: %v", secret);
+}
+
 func (cfg Configuration) handleMetrics(w http.ResponseWriter, r *http.Request) {
 	setDefaultHeaders(w)
 

--- a/backend/db.go
+++ b/backend/db.go
@@ -106,6 +106,11 @@ func (db Database) activeSessionCount() (int, error) {
 	return res, nil
 }
 
+func (db Database) destroySession(secret string) error {
+	_, err := db.db.Exec("DELETE FROM sessions WHERE secret = $1", secret)
+	return err
+}
+
 func (db Database) expire() error {
 	_, err := db.db.Exec("DELETE FROM sessions WHERE created < now() - '1 hour'::interval")
 	return err

--- a/backend/main.go
+++ b/backend/main.go
@@ -237,6 +237,7 @@ func main() {
 	externalMux.HandleFunc("/session/status", cfg.handleSessionStatus)
 	externalMux.HandleFunc("/metrics", cfg.handleMetrics)
 	externalMux.HandleFunc("/session/update", cfg.handleSessionUpdate)
+	externalMux.HandleFunc("/session/destroy", cfg.handleSessionDestroy)
 	externalMux.HandleFunc("/disclose", cfg.handleDisclose)
 	externalMux.HandleFunc("/agent-feed", cfg.handleAgentFeed)
 

--- a/frontend-agents/src/components/App.jsx
+++ b/frontend-agents/src/components/App.jsx
@@ -30,8 +30,6 @@ const destroySession = async (backendUrl, secret) => {
         return;
     }
 
-    console.log("Destroying session with secret", secret);
-
     const res = await axios.get(`${backendUrl}/session/destroy`, {
         params: {
             secret,

--- a/frontend-agents/src/components/App.jsx
+++ b/frontend-agents/src/components/App.jsx
@@ -109,8 +109,11 @@ const App = ({ backendUrl, ccpHost }) => {
 
     const onDestroy = () => {
         setState(state => {
-            destroySession(backendUrl, state.secret);
-            return { mode: 'idle' };
+            try {
+                destroySession(backendUrl, state.secret);
+            } finally {
+                return { mode: 'idle' };
+            }
         })
     };
 

--- a/frontend-agents/src/components/App.jsx
+++ b/frontend-agents/src/components/App.jsx
@@ -25,6 +25,24 @@ const updateStatus = async (backendUrl, secret, status) => {
     }
 };
 
+const destroySession = async (backendUrl, secret) => {
+    if (!secret) {
+        return;
+    }
+
+    console.log("Destroying session with secret", secret);
+
+    const res = await axios.get(`${backendUrl}/session/destroy`, {
+        params: {
+            secret,
+        },
+    });
+
+    if (res.status !== 200) {
+        throw new Error("Failed to destroy session");
+    }
+}
+
 const getDisclosure = async (backendUrl, secret) => {
     const response = await axios.get(`${backendUrl}/disclose`, { params: { secret } });
     if (response.status === 200) {
@@ -87,8 +105,15 @@ const App = ({ backendUrl, ccpHost }) => {
         // When contact has disconnected, go back to idle.
         setState(state => {
             updateStatus(backendUrl, state.secret, 'DONE');
-            return { mode: 'idle' };
+            return { ...state, mode: 'disconnected' };
         });
+    };
+
+    const onDestroy = () => {
+        setState(state => {
+            destroySession(backendUrl, state.secret);
+            return { mode: 'idle' };
+        })
     };
 
     return (
@@ -98,7 +123,7 @@ const App = ({ backendUrl, ccpHost }) => {
             {state.mode === 'unauthorized' && (<Alert severity="warning">You are yet unauthorized and are required to log in using the pop-up.</Alert>)}
             <Grid container spacing={2}>
                 <Grid className="contactinfo" item xs={6}>
-                    <Ccp {...{ setError, onAgent, onContact, onConnect, onDisconnect, ccpHost }} />
+                    <Ccp {...{ setError, onAgent, onContact, onConnect, onDisconnect, onDestroy, ccpHost }} />
                 </Grid>
                 <Grid className="contactinfo" item xs={6}>
                     <ContactInfo {...state} />

--- a/frontend-agents/src/components/App.jsx
+++ b/frontend-agents/src/components/App.jsx
@@ -111,9 +111,10 @@ const App = ({ backendUrl, ccpHost }) => {
         setState(state => {
             try {
                 destroySession(backendUrl, state.secret);
-            } finally {
-                return { mode: 'idle' };
+            } catch (e) {
+                console.error(e);
             }
+            return { mode: 'idle' };
         })
     };
 

--- a/frontend-agents/src/components/Ccp.jsx
+++ b/frontend-agents/src/components/Ccp.jsx
@@ -2,7 +2,7 @@ import React, { useCallback } from 'react';
 
 import 'amazon-connect-streams';
 
-const Ccp = ({ setError, onContact, onAgent, onConnect, onDisconnect, ccpHost }) => {
+const Ccp = ({ setError, onContact, onAgent, onConnect, onDisconnect, onDestroy, ccpHost }) => {
     const ccpUrl = `https://${ccpHost}/connect/ccp-v2`;
 
     const containerRef = useCallback(element => {
@@ -25,17 +25,16 @@ const Ccp = ({ setError, onContact, onAgent, onConnect, onDisconnect, ccpHost })
                 setError("Failed to authenticate, please log in using the popup.");
             });
 
-            connect.agent((_agent) => {
-                onAgent();
-            });
+            connect.agent((_agent) => void onAgent());
 
             connect.contact(async (contact) => {
                 console.log('contact', contact);
 
                 const callAttributes = contact.getAttributes();
 
-                contact.onConnected(() => { onConnect(); });
-                contact.onEnded(() => { onDisconnect(); });
+                contact.onConnected(() => void onConnect());
+                contact.onEnded(() => void onDisconnect());
+                contact.onDestroy(() => void onDestroy());
 
                 onContact(callAttributes.session_secret.value, callAttributes.phonenumber.value);
             });


### PR DESCRIPTION
Destroy session data on 'clear contact' button press in agents frontend. Keep displaying disclosed attributes after client disconnection, until a new connection is made or 'clear contact' is pressed.