### PR TITLE
Hide DTMF from frontend

### DIFF
--- a/backend/api.go
+++ b/backend/api.go
@@ -196,7 +196,7 @@ func (cfg Configuration) handleSessionStatus(w http.ResponseWriter, r *http.Requ
 
 	statusToken := r.FormValue("statusToken")
 	if statusToken == "" {
-		http.Error(w, "No status token passed", http.StatusBadRequest)
+		http.Error(w, "no statusToken passed", http.StatusBadRequest)
 		return
 	}
 
@@ -206,7 +206,7 @@ func (cfg Configuration) handleSessionStatus(w http.ResponseWriter, r *http.Requ
 
 	status, err := cfg.db.getStatus(statusToken)
 	if err != nil {
-		http.Error(w, "unknown token", http.StatusNotFound)
+		http.Error(w, "unknown session", http.StatusNotFound)
 		return
 	}
 

--- a/backend/api.go
+++ b/backend/api.go
@@ -16,7 +16,10 @@ import (
 	"github.com/privacybydesign/irmago/server"
 )
 
+// A DTMF code.
 type DTMF = string
+
+// A Secret allows retrieving the revealed attributes.
 type Secret = string
 
 var upgrader = websocket.Upgrader{
@@ -28,6 +31,7 @@ var upgrader = websocket.Upgrader{
 
 var irmaExternalURLRegexp *regexp.Regexp = regexp.MustCompile(`^http(s?)://(.*)/irma/session`)
 
+// A SessionResponse describes the public parts of a newly created session.
 type SessionResponse struct {
 	SessionPtr  *irma.Qr `json:"sessionPtr,omitempty"`
 	Phonenumber string   `json:"phonenumber,omitempty"`
@@ -38,6 +42,7 @@ func (cfg Configuration) phonenumber(dtmf string) string {
 	return cfg.PhoneNumber + "," + dtmf
 }
 
+// Build the IRMA request for attributes.
 func (cfg Configuration) irmaRequest(purpose string, dtmf string) (irma.RequestorRequest, error) {
 	condiscon, ok := cfg.PurposeMap[purpose]
 	if !ok {
@@ -59,7 +64,7 @@ func setDefaultHeaders(w http.ResponseWriter) {
 	w.Header().Set("Access-Control-Allow-Origin", "*")
 }
 
-// Check if the service is still healty and yield 200 OK if so.
+// Check if the service is still healthy and yield 200 OK if so.
 func (cfg Configuration) handleStatus(w http.ResponseWriter, r *http.Request) {
 	_, err := cfg.db.activeSessionCount()
 
@@ -265,6 +270,8 @@ func (cfg Configuration) handleCall(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// A DiscloseResponse describes the revealed IRMA attributes and the purpose of
+// the call.
 type DiscloseResponse struct {
 	Purpose   string          `json:"purpose"`
 	Disclosed json.RawMessage `json:"disclosed"`

--- a/backend/db.go
+++ b/backend/db.go
@@ -3,6 +3,7 @@ package main
 import (
 	"crypto/rand"
 	"database/sql"
+	"encoding/base64"
 	"fmt"
 	"math/big"
 	"time"
@@ -20,35 +21,39 @@ type Database struct {
 	backendIdentity string
 }
 
-func (db Database) NewSession(purpose string) (DTMF, error) {
+func (db Database) NewSession(purpose string) (DTMF, StatusToken, error) {
 	var err error
 	for attempt := 0; attempt < 10; attempt++ {
 		var n *big.Int
 		n, err = rand.Int(rand.Reader, big.NewInt(10_000_000_000))
 		if err != nil {
-			return "", err
+			err = fmt.Errorf("failed to generate dtmf: %w", err)
+			return "", "", err
 		}
-
 		dtmf := fmt.Sprintf("%010d", n)
-		if err != nil {
-			err = fmt.Errorf("failed to generate secrets: %w", err)
-			return "", err
-		}
 
-		_, err = db.db.Exec("INSERT INTO sessions VALUES (NULL, $1, $2, DEFAULT, DEFAULT, DEFAULT)", dtmf, purpose)
+		statusBytes := make([]byte, 24)
+		_, err := rand.Read(statusBytes)
+		if err != nil {
+			err = fmt.Errorf("failed to generate status token: %w", err)
+			return "", "", err
+		}
+		statusToken := base64.URLEncoding.EncodeToString(statusBytes)
+
+		_, err = db.db.Exec("INSERT INTO sessions VALUES (NULL, $1, $2, $3, DEFAULT, DEFAULT, DEFAULT)", dtmf, statusToken, purpose)
 		pqErr, ok := err.(*pq.Error)
 		if ok && pqErr.Code.Name() == "unique_violation" {
 			time.Sleep(100 * time.Millisecond)
 			continue
 		} else if err != nil {
 			err = fmt.Errorf("failed to store session: %w", err)
-			return "", err
+			return "", "", err
 		}
 
-		return dtmf, nil
+		return dtmf, statusToken, nil
 	}
 	err = fmt.Errorf("failed to find unique secrets: %w", err)
-	return "", err
+	return "", "", err
 }
 
 func (db Database) storeSecret(dtmf string, secret string) error {
@@ -69,14 +74,20 @@ func (db Database) storeDisclosed(secret string, disclosed string) error {
 }
 
 func (db Database) setStatus(secret string, status string) error {
-	_, err := db.db.Exec("UPDATE sessions SET status = $1 WHERE secret = $2", status, secret)
-	db.Notify(secret, "status", status)
+	var statusToken StatusToken
+	row := db.db.QueryRow(`
+		UPDATE sessions
+		SET status = $1
+		WHERE secret = $2
+		RETURNING status_token`, status, secret)
+	err := row.Scan(&statusToken)
+	db.Notify(statusToken, "status", status)
 	return err
 }
 
-func (db Database) getStatus(secret string) (string, error) {
+func (db Database) getStatus(statusToken StatusToken) (string, error) {
 	var status *string
-	row := db.db.QueryRow("SELECT status FROM sessions WHERE secret = $1", secret)
+	row := db.db.QueryRow("SELECT status FROM sessions WHERE status_token = $1", statusToken)
 	err := row.Scan(&status)
 	if status == nil {
 		return "", err

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.6.4 // indirect
 	github.com/jasonlvhit/gocron v0.0.0-20191228163020-98b59b546dee // indirect
 	github.com/jinzhu/gorm v1.9.12 // indirect
+	github.com/kelseyhightower/envconfig v1.4.0
 	github.com/lib/pq v1.3.0
 	github.com/mattn/go-colorable v0.1.6 // indirect
 	github.com/mgutz/ansi v0.0.0-20170206155736-9520e82c474b // indirect
@@ -23,8 +24,6 @@ require (
 	github.com/timshannon/bolthold v0.0.0-20200308034358-09aaf76b2c32 // indirect
 	github.com/x-cray/logrus-prefixed-formatter v0.5.2 // indirect
 	golang.org/x/net v0.0.0-20200301022130-244492dfa37a // indirect
-	github.com/aws/aws-sdk-go v1.30.7
-	github.com/kelseyhightower/envconfig v1.4.0
 )
 
 replace astuart.co/go-sse => github.com/sietseringers/go-sse v0.0.0-20200223201439-6cc042ab6f6d

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -6,6 +6,9 @@ CREATE TABLE sessions (
 	secret text,
 	-- DTMF code used to connect the corresponding call.
 	dtmf text UNIQUE NOT NULL,
+	-- The status token grants permission to retrieve the session status,
+	-- but not to any disclosed attributes.
+	status_token text UNIQUE NOT NULL,
 	-- Identifier for the call purpose of this session.
 	purpose text,
 	-- The IRMA attributes that were disclosed.

--- a/frontend-public/src/components/App.jsx
+++ b/frontend-public/src/components/App.jsx
@@ -37,9 +37,9 @@ const App = ({ hostname, purpose, onClose, irmaJsLang }) => {
                 return;
             }
 
-            const { sessionPtr, dtmf } = response.data;
+            const { sessionPtr, statusToken } = response.data;
 
-            const client = new WebSocket(`wss://${hostname}/session/status?dtmf=${encodeURIComponent(dtmf)}`);
+            const client = new WebSocket(`wss://${hostname}/session/status?statusToken=${encodeURIComponent(statusToken)}`);
 
             client.addEventListener('error', (error) => {
                 console.error('Connect Error: ', error);


### PR DESCRIPTION
I recommend reviewing individual commits.

This prevents the public frontend from obtaining the DTMF code and allows it to request the session status using a dedicated status token instead.

I was unable to test this fully because my local development environment is broken.